### PR TITLE
Adding Rocq Opam Version Support

### DIFF
--- a/.travis.yml.mustache
+++ b/.travis.yml.mustache
@@ -87,6 +87,14 @@ jobs:
     - NJOBS=2
     <<: *OPAM
 {{/ tested_coq_opam_versions }}
+  # Test supported versions of Rocq via OPAM
+{{# tested_rocq_opam_versions }}
+  - env:
+    - COQ_IMAGE={{ repo }}{{^ repo }}rocq/rocq-prover{{/ repo }}:{{ version }}
+    - PACKAGE={{ opam_name }}{{^ opam_name }}coq-{{ shortname }}{{/ opam_name }}.{{ opam-file-version }}{{^ opam-file-version }}dev{{/ opam-file-version }}
+    - NJOBS=2
+    <<: *OPAM
+{{/ tested_rocq_opam_versions }}
 
 {{# extracted }}
   # Test extracted supported versions of Coq via OPAM

--- a/config.yml.mustache
+++ b/config.yml.mustache
@@ -66,3 +66,8 @@ workflows:
         name: "{{ repo }}{{^ repo }}Coq{{/ repo }} {{ version }}"
         coq: "{{ repo }}{{^ repo }}coqorg/coq{{/ repo }}:{{ version }}"
 {{/ tested_coq_opam_versions }}
+{{# tested_rocq_opam_versions }}
+    - build:
+        name: "{{ repo }}{{^ repo }}Rocq{{/ repo }} {{ version }}"
+        coq: "{{ repo }}{{^ repo }}rocq/rocq-prover{{/ repo }}:{{ version }}"
+{{/ tested_rocq_opam_versions }}

--- a/docker-action.yml.mustache
+++ b/docker-action.yml.mustache
@@ -24,6 +24,9 @@ jobs:
 {{# tested_coq_opam_versions }}
           - '{{ repo }}{{^ repo }}coqorg/coq{{/ repo }}:{{ version }}'
 {{/ tested_coq_opam_versions }}
+{{# tested_rocq_opam_versions }}
+          - '{{ repo }}{{^ repo }}rocq/rocq-prover{{/ repo }}:{{ version }}'
+{{/ tested_rocq_opam_versions }}
       fail-fast: false
     steps:
       - uses: actions/checkout@v4

--- a/ref.yml
+++ b/ref.yml
@@ -477,6 +477,34 @@ fields:
         - .travis.yml
         - docker-action.yml
         - config.yml
+  - tested_rocq_opam_versions:
+      type: list
+      item_fields:
+        - version:
+            required: true
+            description: >
+              Docker tag supported by rocq/rocq-prover:
+              https://hub.docker.com/r/rocq/rocq-prover/tags
+              Quote the strings, otherwise '9.10' becomes '9.1'.
+            examples:
+              - "9.0"
+              - "dev-native-flambda"
+        - repo:
+            required: false
+            description: >
+              Docker repository supporting the given docker tag.
+              Defaults to 'rocq/rocq-prover'.
+            examples:
+              - "mathcomp/mathcomp"
+              - "mathcomp/mathcomp-dev"
+            used:
+              - .travis.yml
+              - docker-action.yml
+              - config.yml
+      used:
+        - .travis.yml
+        - docker-action.yml
+        - config.yml
   - ci_cron_schedule:
       required: false
       description: >


### PR DESCRIPTION
In reference to issue #134 .

I was hoping for some guidance on if further changes would be needed for the `tested_coq_nix_versions` and `extracted_tested_coq_opam_versions`?

Additionally, in the travis yml line 94 I left packages as `coq-`, does this seem reasonable or should it be `rocq-`?